### PR TITLE
Add wasm wrapper over gdb-remote component

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -47,6 +47,7 @@
 #include "lldb/Utility/StructuredData.h"
 #include "lldb/Utility/TraceOptions.h"
 #include "lldb/Utility/UserIDResolver.h"
+#include "lldb/Utility/WasmWrapper.h"
 #include "lldb/lldb-private.h"
 
 #include "llvm/ADT/ArrayRef.h"
@@ -555,6 +556,10 @@ public:
   uint32_t GetAddressByteSize() const;
 
   uint32_t GetUniqueID() const { return m_process_unique_id; }
+
+  /// WASM specific
+  virtual bool CanDebugWasm() { return false; }
+  virtual WasmWrapper *GetWasmWrapper () { return nullptr; }
 
   /// Check if a plug-in instance can debug the file in \a module.
   ///
@@ -2748,7 +2753,7 @@ protected:
   StructuredDataPluginMap m_structured_data_plugin_map;
 
   enum { eCanJITDontKnow = 0, eCanJITYes, eCanJITNo } m_can_jit;
-  
+
   std::unique_ptr<UtilityFunction> m_dlopen_utility_func_up;
   llvm::once_flag m_dlopen_utility_func_flag_once;
 

--- a/lldb/include/lldb/Utility/WasmWrapper.h
+++ b/lldb/include/lldb/Utility/WasmWrapper.h
@@ -1,0 +1,32 @@
+//===-- WasmWrapper.h --------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef liblldb_WasmWrapper_h_
+#define liblldb_WasmWrapper_h_
+
+#include <vector>
+#include "lldb/lldb-types.h"
+
+namespace lldb_private {
+
+class WasmWrapper {
+
+public:
+  // WebAssembly-specific commands
+  virtual bool GetWasmGlobal(uint32_t module_id, int index, uint64_t &value) = 0;
+  virtual bool GetWasmLocal(uint32_t module_id, int frame_index, int index,
+                    uint64_t &value) = 0;
+  virtual bool GetWasmStackValue(uint32_t module_id, int index, uint64_t &value) = 0;
+  virtual bool WasmReadMemory(uint32_t module_id, lldb::addr_t vm_addr, void *buf,
+                      size_t size) = 0;
+  virtual bool GetWasmCallStack(std::vector<lldb::addr_t> &call_stack_pcs) = 0;
+};
+
+} // end lldb_private
+
+#endif // liblldb_WasmWrapper_h_

--- a/lldb/source/Plugins/Process/Utility/UnwindWasm.cpp
+++ b/lldb/source/Plugins/Process/Utility/UnwindWasm.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "UnwindWasm.h"
-#include "Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.h"
 #include "Plugins/Process/gdb-remote/GDBRemoteRegisterContext.h"
 #include "Plugins/Process/gdb-remote/ProcessGDBRemote.h"
 #include "Plugins/Process/gdb-remote/ThreadGDBRemote.h"
@@ -39,13 +38,11 @@ uint32_t UnwindWasm::DoGetFrameCount() {
     m_unwind_complete = true;
     m_frames.clear();
 
-    process_gdb_remote::ProcessGDBRemote *process =
-        (process_gdb_remote::ProcessGDBRemote *)GetThread().GetProcess().get();
+    Process *process = GetThread().GetProcess().get();
     if (process) {
-      process_gdb_remote::GDBRemoteCommunicationClient *gdb_comm =
-          &process->GetGDBRemote();
-      if (gdb_comm) {
-        if (!gdb_comm->GetWasmCallStack(m_frames)) {
+      WasmWrapper *wasm_wrapper = process->GetWasmWrapper();
+      if (wasm_wrapper) {
+        if (!wasm_wrapper->GetWasmCallStack(m_frames)) {
           m_frames.clear();
         }
       }

--- a/lldb/source/Plugins/Process/gdb-remote/CMakeLists.txt
+++ b/lldb/source/Plugins/Process/gdb-remote/CMakeLists.txt
@@ -30,6 +30,7 @@ add_lldb_library(lldbPluginProcessGDBRemote PLUGIN
   GDBRemoteCommunicationServerLLGS.cpp
   GDBRemoteCommunicationServerPlatform.cpp
   GDBRemoteRegisterContext.cpp
+  GDBRemoteWasmWrapper.cpp
   ProcessGDBRemote.cpp
   ProcessGDBRemoteLog.cpp
   ThreadGDBRemote.cpp

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteWasmWrapper.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteWasmWrapper.cpp
@@ -1,0 +1,42 @@
+//===-- GDBRemoteWasmWrapper.cpp -------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "GDBRemoteWasmWrapper.h"
+
+#include "Plugins/Process/gdb-remote/ProcessGDBRemote.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+GDBRemoteWasmWrapper::GDBRemoteWasmWrapper(process_gdb_remote::GDBRemoteCommunicationClient *gdb_remote_com_client) {
+  gdb_comm = gdb_remote_com_client;
+}
+
+GDBRemoteWasmWrapper::~GDBRemoteWasmWrapper(){}
+
+// WebAssembly-specific commands
+bool GDBRemoteWasmWrapper::GetWasmGlobal(uint32_t module_id, int index, uint64_t &value) {
+  return gdb_comm->GetWasmGlobal(module_id, index, value);
+}
+
+bool GDBRemoteWasmWrapper::GetWasmLocal(uint32_t module_id, int frame_index, int index,
+                    uint64_t &value) {
+  return gdb_comm->GetWasmLocal(module_id, frame_index, index, value);
+}
+
+bool GDBRemoteWasmWrapper::GetWasmStackValue(uint32_t module_id, int index, uint64_t &value) {
+  return gdb_comm->GetWasmStackValue(module_id, index, value);
+}
+bool GDBRemoteWasmWrapper::WasmReadMemory(uint32_t module_id, lldb::addr_t vm_addr, void *buf,
+                    size_t size) {
+  return gdb_comm->WasmReadMemory(module_id, vm_addr, buf, size);
+}
+
+bool GDBRemoteWasmWrapper::GetWasmCallStack(std::vector<lldb::addr_t> &call_stack_pcs) {
+  return gdb_comm->GetWasmCallStack(call_stack_pcs);
+}

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteWasmWrapper.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteWasmWrapper.h
@@ -1,0 +1,39 @@
+//===-- GDBRemoteWasmWrapper.h --------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef liblldb_GDBRemoteWasmWrapper_h_
+#define liblldb_GDBRemoteWasmWrapper_h_
+
+#include <vector>
+#include "Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.h"
+#include "lldb/Utility/WasmWrapper.h"
+
+namespace lldb_private {
+
+class GDBRemoteWasmWrapper : public WasmWrapper {
+
+public:
+  GDBRemoteWasmWrapper(process_gdb_remote::GDBRemoteCommunicationClient *gdb_remote_com_client);
+  ~GDBRemoteWasmWrapper();
+
+  // WebAssembly-specific commands
+  bool GetWasmGlobal(uint32_t module_id, int index, uint64_t &value) override;
+  bool GetWasmLocal(uint32_t module_id, int frame_index, int index,
+                    uint64_t &value) override;
+  bool GetWasmStackValue(uint32_t module_id, int index, uint64_t &value) override;
+  bool WasmReadMemory(uint32_t module_id, lldb::addr_t vm_addr, void *buf,
+                      size_t size) override;
+  bool GetWasmCallStack(std::vector<lldb::addr_t> &call_stack_pcs) override;
+
+private:
+  process_gdb_remote::GDBRemoteCommunicationClient *gdb_comm;
+};
+
+} // namespace lldb_private
+
+#endif // liblldb_GDBRemoteWasmWrapper_h_

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
@@ -35,6 +35,7 @@
 #include "GDBRemoteCommunicationClient.h"
 #include "GDBRemoteCommunicationReplayServer.h"
 #include "GDBRemoteRegisterContext.h"
+#include "GDBRemoteWasmWrapper.h"
 
 #include "llvm/ADT/DenseMap.h"
 
@@ -231,6 +232,11 @@ public:
   std::string HarmonizeThreadIdsForProfileData(
       StringExtractorGDBRemote &inputStringExtractor);
 
+  bool CanDebugWasm() override { return true; }
+  WasmWrapper *GetWasmWrapper() override {
+    return new GDBRemoteWasmWrapper(&GetGDBRemote());
+  };
+
 protected:
   friend class ThreadGDBRemote;
   friend class GDBRemoteCommunicationClient;
@@ -386,7 +392,7 @@ protected:
   DynamicLoader *GetDynamicLoader() override;
 
   bool GetGDBServerRegisterInfoXMLAndProcess(ArchSpec &arch_to_use,
-                                             std::string xml_filename, 
+                                             std::string xml_filename,
                                              uint32_t &cur_reg_num,
                                              uint32_t &reg_offset);
 


### PR DESCRIPTION
This will help since later we want to mock response from gdb-server or replace with query to engine.